### PR TITLE
fix: turn on graphs + ignore few files/dirs

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -4,7 +4,7 @@ OUTPUT_DIRECTORY       = docs/
 
 INPUT                  = .
 USE_MDFILE_AS_MAINPAGE = ./README.md
-EXCLUDE                = ./external
+EXCLUDE                = ./external ./build ./.clang-tidy ./.clang-format
 
 FILE_PATTERNS          = *.cxx *.cpp *.c *.h *.hxx *.hpp *.h++ *.md *.txt *.clang-format *.clang-tidy
 
@@ -20,3 +20,17 @@ HTML_OUTPUT            = html
 GENERATE_LATEX         = NO
 
 MARKDOWN_SUPPORT       = YES
+
+CLASS_DIAGRAMS         = YES
+HAVE_DOT               = YES
+CLASS_GRAPH            = YES
+COLLABORATION_GRAPH    = YES
+UML_LOOK               = YES
+UML_LIMIT_NUM_FIELDS   = 50
+TEMPLATE_RELATIONS     = YES
+DOT_GRAPH_MAX_NODES    = 100
+MAX_DOT_GRAPH_DEPTH    = 0
+DOT_TRANSPARENT        = YES
+CALL_GRAPH             = YES
+CALLER_GRAPH           = YES
+DIRECTORY_GRAPH        = YES


### PR DESCRIPTION
The documentation - https://saransh-cpp.github.io/ROOT/files.html - right now displays the `build` folder:

<img width="327" height="576" alt="image" src="https://github.com/user-attachments/assets/31db80cd-c3b8-473b-a800-58f32c3b8fe8" />

And the linter and formatter configs, which should be ignored.

This PR also turns on all kinds of graphs for functions, classes, and directories.