### PR TITLE
refactor: make writer interface identical for users

### DIFF
--- a/ROOT/ROOT/main.cpp
+++ b/ROOT/ROOT/main.cpp
@@ -199,14 +199,16 @@ int main(int argc, char** argv) {
         Writer<Eigen::MatrixX2d> writer(results, WritingMethod::CONSOLE);
         writer.write();
     } else if (!write_to_csv.empty()) {
-        Writer<Eigen::MatrixX2d> writer(results, WritingMethod::CSV);
-        writer.write(write_to_csv, w_csv_sep, append_or_overwrite == 'o');
+        Writer<Eigen::MatrixX2d> writer(results, WritingMethod::CSV, write_to_csv, w_csv_sep,
+                                        append_or_overwrite == 'o');
+        writer.write();
     } else if (!write_to_dat.empty()) {
-        Writer<Eigen::MatrixX2d> writer(results, WritingMethod::DAT);
-        writer.write(write_to_dat, ' ', append_or_overwrite == 'o');
+        Writer<Eigen::MatrixX2d> writer(results, WritingMethod::DAT, write_to_dat, ' ', append_or_overwrite == 'o');
+        writer.write();
     } else if (!write_with_gnuplot.empty()) {
-        Writer<Eigen::MatrixX2d> writer(results, WritingMethod::GNUPLOT);
-        writer.write(write_with_gnuplot, ',', append_or_overwrite == 'o');
+        Writer<Eigen::MatrixX2d> writer(results, WritingMethod::GNUPLOT, write_with_gnuplot, ',',
+                                        append_or_overwrite == 'o');
+        writer.write();
     }
 
     return 0;

--- a/ROOT/ROOT/writer.hpp
+++ b/ROOT/ROOT/writer.hpp
@@ -14,9 +14,13 @@ template <>
 void PrinterGNUPlot<Eigen::Vector2d>::generate_gnuplot_script() const;
 
 template <>
-Writer<Eigen::MatrixX2d>::Writer(const Eigen::MatrixX2d& vals_to_write, WritingMethod write_method) {
+Writer<Eigen::MatrixX2d>::Writer(const Eigen::MatrixX2d& vals_to_write, WritingMethod write_method,
+                                 std::string filename, char separator, bool overwrite) {
     this->values = vals_to_write;
     this->method = write_method;
+    this->separator = separator;
+    this->overwrite = overwrite;
+    this->filename = filename;
 }
 
 template <>
@@ -25,11 +29,11 @@ void Writer<Eigen::MatrixX2d>::print_final_result() const {
 }
 
 template <>
-void Writer<Eigen::MatrixX2d>::write(std::string filename, char sep, bool overwrite) {
+void Writer<Eigen::MatrixX2d>::write() {
     print_final_result();
 
     std::unique_ptr<PrinterBase<Eigen::Vector2d>> printer;
-    build_printer(printer, filename);
+    build_printer(printer);
 
     for (int i = 0; i < this->values.rows(); i++) {
         Eigen::Vector2d row = this->values.row(i);
@@ -45,20 +49,19 @@ void Writer<Eigen::MatrixX2d>::write(std::string filename, char sep, bool overwr
 
 template <typename T>
 template <typename V>
-void Writer<T>::build_printer(std::unique_ptr<PrinterBase<V>>& printer, std::string filename, char sep,
-                              bool overwrite) {
+void Writer<T>::build_printer(std::unique_ptr<PrinterBase<V>>& printer) {
     switch (this->method) {
         case WritingMethod::CONSOLE:
             printer = std::make_unique<PrinterCLI<V>>();
             break;
         case WritingMethod::CSV:
-            printer = std::make_unique<PrinterCSV<V>>(filename, sep, overwrite);
+            printer = std::make_unique<PrinterCSV<V>>(this->filename, this->separator, this->overwrite);
             break;
         case WritingMethod::DAT:
-            printer = std::make_unique<PrinterDAT<V>>(filename, overwrite);
+            printer = std::make_unique<PrinterDAT<V>>(this->filename, this->overwrite);
             break;
         case WritingMethod::GNUPLOT:
-            printer = std::make_unique<PrinterGNUPlot<V>>(filename, overwrite);
+            printer = std::make_unique<PrinterGNUPlot<V>>(this->filename, this->overwrite);
             break;
         default:
             throw std::runtime_error("Unknown writing method");

--- a/ROOT/ROOT/writer_def.hpp
+++ b/ROOT/ROOT/writer_def.hpp
@@ -32,6 +32,9 @@ class Writer {
   protected:
     T values;              //!< Templated values to write to allow different usage of the class
     WritingMethod method;  //!< Method to write with - defined thanks to @author Saransh-cpp config
+    char separator;        //!< Separator for .csv files
+    bool overwrite;        //!< Option to overwrite or append the output file
+    std::string filename;  //!< Name of the output file
 
   public:
     /**
@@ -39,25 +42,21 @@ class Writer {
      *
      * @param vals_to_write Values to be written, which will be stored in values argument
      * @param write_method Method to be used, which will be stored in method argument
-     */
-    Writer(const T& vals_to_write, WritingMethod write_method);
-    /** @brief Method to run the printing loop and correctly initialize the Printer
-     *
-     * @param filename Name of the file to write on (optional)
-     * @param sep Separator for .csv extension files (optional)
+     * @param separator Separator for .csv extension files (optional)
      * @param overwrite Option to overwrite or append to the file (optional)
      */
-    void write(std::string filename = "", char sep = ',', bool overwrite = true);
+    Writer(const T& vals_to_write, WritingMethod write_method, std::string filename = "output", char separator = ',',
+           bool overwrite = true);
+    /** @brief Method to run the printing loop and correctly initialize the Printer
+     *
+     */
+    void write();
     /** @brief Method to convert the generic Printer into a typed one for a specific output destination
      *
      * @param printer The original abstract printer
-     * @param filename The file to write on
-     * @param sep The separator for .csv files
-     * @param overwrite Option to overwrite or append the file
      */
     template <typename V>
-    void build_printer(std::unique_ptr<PrinterBase<V>>& printer, std::string filename, char sep = ',',
-                       bool overwrite = true);
+    void build_printer(std::unique_ptr<PrinterBase<V>>& printer);
     /** @brief Helper just to print the final result of the solver process*/
     void print_final_result() const;
 };


### PR DESCRIPTION
Just move the arguments around so that the interface in `main` is uniform for every method and type